### PR TITLE
try to avoid passing around infinite values

### DIFF
--- a/src/main/java/io/inscopemetrics/kairosdb/aggregators/HistogramMeanAggregator.java
+++ b/src/main/java/io/inscopemetrics/kairosdb/aggregators/HistogramMeanAggregator.java
@@ -78,6 +78,9 @@ public final class HistogramMeanAggregator extends RangeAggregator {
                 }
             }
 
+            if (count == 0) {
+                return Collections.emptyList();
+            }
             return Collections.singletonList(dataPointFactory.createDataPoint(returnTime, sum / count));
         }
     }


### PR DESCRIPTION
- reject data points that contain NaN/infinite values
- if empty histograms are somehow encountered in the MeanAggregator, skip that data point entirely instead of creating a NaN value that will blow up down the road

Before:
```bash
$ curl http://localhost:8082/api/v1/datapoints -XPOST --data-binary '[{"name":"foo", "type":"histogram", "tags":{"a":"a"}, "datapoints":[[1500000000000, {"min":0, "max":1, "sum": 1, "mean": "Infinity", "bins":{"0":"1","1":"1"}}]]}]'; echo

$ curl http://localhost:8082/api/v1/datapoints/query -XPOST --data-binary '{"start_absolute":1500000000000, "end_absolute":1500000000000, "metrics":[{"name":"foo", "aggregators":[]}]}'; echo
{"errors":["org.json.JSONException: JSON does not allow non-finite numbers."]}
```

After:
```bash
$ curl http://localhost:8082/api/v1/datapoints -XPOST --data-binary '[{"name":"foo", "type":"histogram", "tags":{"a":"a"}, "datapoints":[[1500000000000, {"min":0, "max":1, "sum": 1, "mean": "Infinity", "bins":{"0":"1","1":"1"}}]]}]'; echo
{"errors":["mean has non-finite value Infinity"]}
```