### PR TITLE
use forked KairosDB 🌶️

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apk --no-cache --update add bash
 RUN apk --no-cache --update add curl; \
   mkdir /opt; \
   cd /opt; \
-  curl -L https://github.com/kairosdb/kairosdb/releases/download/v1.2.2/kairosdb-1.2.2-1.tar.gz | tar zxfp - ; \
+  curl -L https://github.com/ddimensia/kairosdb/releases/download/v1.2.1-dd-4/kairosdb-1.2.1-dd-4.tar.gz | tar zxfp - ; \
   apk del curl
 
 # Build: Extensions


### PR DESCRIPTION
I have heard rumblings (from @vjkoskela, specifically) about how we might end up forking KairosDB. This diff does that, in the most naive, straightforward way possible. ("Why do this now?" Because I want to get the `datapoints/query/cardinality` endpoint out into our production environment, which requires adding an endpoint to MPortal, but that endpoint isn't a valid endpoint for `github.com/kairosdb/kairosdb`.)

I expect this diff to get blocked / shot down for some combination of the following reasons:
- we're not all on the same page about whether forking KairosDB is a good idea
- if we _do_ settle on forking KairosDB, we want to fork it into `InscopeMetrics`, not use @ddimensia's fork

[+@BrandonArp so he can weigh in if desired]